### PR TITLE
feat: Termux local tools (exec + python)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -8,6 +8,7 @@
   <uses-permission android:name="android.permission.POST_PROMOTED_NOTIFICATIONS" />
   <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
   <uses-permission android:name="android.permission.CHANGE_WIFI_MULTICAST_STATE" />
+  <uses-permission android:name="com.termux.permission.RUN_COMMAND" />
 
   <uses-feature
     android:name="android.hardware.camera"
@@ -69,6 +70,10 @@
       android:name="com.yalantis.ucrop.UCropActivity"
       android:theme="@style/Theme.AppCompat.Light.NoActionBar"/>
 
+    <service
+      android:name=".data.ai.tools.termux.TermuxResultService"
+      android:exported="false" />
+
     <provider
       android:name="androidx.core.content.FileProvider"
       android:authorities="${applicationId}.fileprovider"
@@ -92,6 +97,7 @@
   </application>
 
   <queries>
+    <package android:name="com.termux" />
     <intent>
       <action android:name="android.intent.action.TTS_SERVICE" />
     </intent>

--- a/app/src/main/java/me/rerere/rikkahub/RouteActivity.kt
+++ b/app/src/main/java/me/rerere/rikkahub/RouteActivity.kt
@@ -95,6 +95,7 @@ import me.rerere.rikkahub.ui.pages.setting.SettingProviderDetailPage
 import me.rerere.rikkahub.ui.pages.setting.SettingProviderPage
 import me.rerere.rikkahub.ui.pages.setting.SettingSearchPage
 import me.rerere.rikkahub.ui.pages.setting.SettingTTSPage
+import me.rerere.rikkahub.ui.pages.setting.SettingTermuxPage
 import me.rerere.rikkahub.ui.pages.setting.SettingWebPage
 import me.rerere.rikkahub.ui.pages.share.handler.ShareHandlerPage
 import me.rerere.rikkahub.ui.pages.translator.TranslatorPage
@@ -355,6 +356,10 @@ class RouteActivity : ComponentActivity() {
                         SettingMcpPage()
                     }
 
+                    composable<Screen.SettingTermux> {
+                        SettingTermuxPage()
+                    }
+
                     composable<Screen.SettingDonate> {
                         SettingDonatePage()
                     }
@@ -519,6 +524,9 @@ sealed interface Screen {
 
     @Serializable
     data object SettingMcp : Screen
+
+    @Serializable
+    data object SettingTermux : Screen
 
     @Serializable
     data object SettingDonate : Screen

--- a/app/src/main/java/me/rerere/rikkahub/data/ai/tools/termux/TermuxCommandManager.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/ai/tools/termux/TermuxCommandManager.kt
@@ -1,0 +1,109 @@
+package me.rerere.rikkahub.data.ai.tools.termux
+
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.os.Build
+import androidx.core.content.ContextCompat
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.withTimeout
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicInteger
+
+class TermuxCommandManager(
+    private val context: Context,
+) {
+    private val executionIdCounter = AtomicInteger(1000)
+    private val pending = ConcurrentHashMap<Int, CompletableDeferred<TermuxResult>>()
+
+    suspend fun run(request: TermuxRunCommandRequest): TermuxResult {
+        ensureTermuxInstalled()
+        ensurePermissionGranted()
+
+        val executionId = executionIdCounter.getAndIncrement()
+        val deferred = CompletableDeferred<TermuxResult>()
+        pending[executionId] = deferred
+
+        val resultIntent = Intent(context, TermuxResultService::class.java).apply {
+            putExtra(TermuxResultService.EXTRA_EXECUTION_ID, executionId)
+        }
+        val pendingIntentFlags = PendingIntent.FLAG_ONE_SHOT or
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) PendingIntent.FLAG_MUTABLE else 0
+        val pendingIntent = PendingIntent.getService(
+            context,
+            executionId,
+            resultIntent,
+            pendingIntentFlags,
+        )
+
+        val intent = Intent().apply {
+            setClassName(TermuxProtocol.TERMUX_PACKAGE_NAME, TermuxProtocol.RUN_COMMAND_SERVICE)
+            action = TermuxProtocol.ACTION_RUN_COMMAND
+
+            putExtra(TermuxProtocol.EXTRA_COMMAND_PATH, request.commandPath)
+            putExtra(TermuxProtocol.EXTRA_ARGUMENTS, request.arguments.toTypedArray())
+            putExtra(TermuxProtocol.EXTRA_WORKDIR, request.workdir)
+            putExtra(TermuxProtocol.EXTRA_BACKGROUND, request.background)
+            putExtra(TermuxProtocol.EXTRA_PENDING_INTENT, pendingIntent)
+
+            request.stdin?.let { putExtra(TermuxProtocol.EXTRA_STDIN, it) }
+            request.label?.let { putExtra(TermuxProtocol.EXTRA_COMMAND_LABEL, it) }
+            request.description?.let { putExtra(TermuxProtocol.EXTRA_COMMAND_DESCRIPTION, it) }
+        }
+
+        runCatching {
+            context.startService(intent)
+        }.onFailure { e ->
+            pending.remove(executionId)
+            throw e
+        }
+
+        return runCatching {
+            withTimeout(request.timeoutMs) {
+                deferred.await()
+            }
+        }.getOrElse {
+            pending.remove(executionId)
+            TermuxResult(timedOut = true, errMsg = "Timed out after ${request.timeoutMs}ms")
+        }.also {
+            pending.remove(executionId)
+        }
+    }
+
+    fun complete(executionId: Int, result: TermuxResult) {
+        pending.remove(executionId)?.complete(result)
+    }
+
+    private fun ensureTermuxInstalled() {
+        val pm = context.packageManager
+        val installed = runCatching {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                pm.getPackageInfo(
+                    TermuxProtocol.TERMUX_PACKAGE_NAME,
+                    PackageManager.PackageInfoFlags.of(0),
+                )
+            } else {
+                @Suppress("DEPRECATION")
+                pm.getPackageInfo(TermuxProtocol.TERMUX_PACKAGE_NAME, 0)
+            }
+        }.isSuccess
+
+        check(installed) {
+            "Termux is not installed. Please install Termux (com.termux) first."
+        }
+    }
+
+    private fun ensurePermissionGranted() {
+        val granted = ContextCompat.checkSelfPermission(
+            context,
+            TermuxProtocol.PERMISSION_RUN_COMMAND,
+        ) == PackageManager.PERMISSION_GRANTED
+
+        check(granted) {
+            "Permission ${TermuxProtocol.PERMISSION_RUN_COMMAND} is not granted. " +
+                "Grant it in Android Settings -> App Info -> Permissions -> Additional permissions."
+        }
+    }
+}
+

--- a/app/src/main/java/me/rerere/rikkahub/data/ai/tools/termux/TermuxProtocol.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/ai/tools/termux/TermuxProtocol.kt
@@ -1,0 +1,29 @@
+package me.rerere.rikkahub.data.ai.tools.termux
+
+object TermuxProtocol {
+    const val TERMUX_PACKAGE_NAME = "com.termux"
+    const val RUN_COMMAND_SERVICE = "com.termux.app.RunCommandService"
+
+    const val PERMISSION_RUN_COMMAND = "com.termux.permission.RUN_COMMAND"
+
+    const val ACTION_RUN_COMMAND = "com.termux.RUN_COMMAND"
+
+    const val EXTRA_COMMAND_PATH = "com.termux.RUN_COMMAND_PATH"
+    const val EXTRA_ARGUMENTS = "com.termux.RUN_COMMAND_ARGUMENTS"
+    const val EXTRA_WORKDIR = "com.termux.RUN_COMMAND_WORKDIR"
+    const val EXTRA_BACKGROUND = "com.termux.RUN_COMMAND_BACKGROUND"
+    const val EXTRA_STDIN = "com.termux.RUN_COMMAND_STDIN"
+    const val EXTRA_PENDING_INTENT = "com.termux.RUN_COMMAND_PENDING_INTENT"
+    const val EXTRA_COMMAND_LABEL = "com.termux.RUN_COMMAND_COMMAND_LABEL"
+    const val EXTRA_COMMAND_DESCRIPTION = "com.termux.RUN_COMMAND_COMMAND_DESCRIPTION"
+
+    const val RESULT_BUNDLE = "result"
+    const val RESULT_STDOUT = "stdout"
+    const val RESULT_STDOUT_ORIGINAL_LENGTH = "stdout_original_length"
+    const val RESULT_STDERR = "stderr"
+    const val RESULT_STDERR_ORIGINAL_LENGTH = "stderr_original_length"
+    const val RESULT_EXIT_CODE = "exitCode"
+    const val RESULT_ERR = "err"
+    const val RESULT_ERRMSG = "errmsg"
+}
+

--- a/app/src/main/java/me/rerere/rikkahub/data/ai/tools/termux/TermuxResult.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/ai/tools/termux/TermuxResult.kt
@@ -1,0 +1,13 @@
+package me.rerere.rikkahub.data.ai.tools.termux
+
+data class TermuxResult(
+    val stdout: String = "",
+    val stderr: String = "",
+    val exitCode: Int? = null,
+    val errCode: Int? = null,
+    val errMsg: String? = null,
+    val stdoutOriginalLength: Int? = null,
+    val stderrOriginalLength: Int? = null,
+    val timedOut: Boolean = false,
+)
+

--- a/app/src/main/java/me/rerere/rikkahub/data/ai/tools/termux/TermuxResultService.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/ai/tools/termux/TermuxResultService.kt
@@ -1,0 +1,63 @@
+package me.rerere.rikkahub.data.ai.tools.termux
+
+import android.app.Service
+import android.content.Intent
+import android.os.IBinder
+import org.koin.android.ext.android.inject
+
+class TermuxResultService : Service() {
+    private val termuxCommandManager: TermuxCommandManager by inject()
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        if (intent == null) {
+            stopSelf(startId)
+            return START_NOT_STICKY
+        }
+
+        val executionId = intent.getIntExtra(EXTRA_EXECUTION_ID, -1)
+        if (executionId == -1) {
+            stopSelf(startId)
+            return START_NOT_STICKY
+        }
+
+        val resultBundle = intent.getBundleExtra(TermuxProtocol.RESULT_BUNDLE)
+        val result = if (resultBundle == null) {
+            TermuxResult(
+                errMsg = "Missing result bundle from Termux callback",
+            )
+        } else {
+            TermuxResult(
+                stdout = resultBundle.getString(TermuxProtocol.RESULT_STDOUT, ""),
+                stderr = resultBundle.getString(TermuxProtocol.RESULT_STDERR, ""),
+                exitCode = if (resultBundle.containsKey(TermuxProtocol.RESULT_EXIT_CODE)) {
+                    resultBundle.getInt(TermuxProtocol.RESULT_EXIT_CODE)
+                } else {
+                    null
+                },
+                errCode = if (resultBundle.containsKey(TermuxProtocol.RESULT_ERR)) {
+                    resultBundle.getInt(TermuxProtocol.RESULT_ERR)
+                } else {
+                    null
+                },
+                errMsg = resultBundle.getString(TermuxProtocol.RESULT_ERRMSG),
+                stdoutOriginalLength = resultBundle
+                    .getString(TermuxProtocol.RESULT_STDOUT_ORIGINAL_LENGTH)
+                    ?.toIntOrNull(),
+                stderrOriginalLength = resultBundle
+                    .getString(TermuxProtocol.RESULT_STDERR_ORIGINAL_LENGTH)
+                    ?.toIntOrNull(),
+            )
+        }
+
+        termuxCommandManager.complete(executionId, result)
+        stopSelf(startId)
+        return START_NOT_STICKY
+    }
+
+    companion object {
+        const val EXTRA_EXECUTION_ID = "execution_id"
+    }
+}
+

--- a/app/src/main/java/me/rerere/rikkahub/data/ai/tools/termux/TermuxRunCommandRequest.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/ai/tools/termux/TermuxRunCommandRequest.kt
@@ -1,0 +1,15 @@
+package me.rerere.rikkahub.data.ai.tools.termux
+
+data class TermuxRunCommandRequest(
+    val commandPath: String,
+    val arguments: List<String> = emptyList(),
+    val workdir: String,
+    val stdin: String? = null,
+    val background: Boolean = true,
+    val timeoutMs: Long = DEFAULT_TIMEOUT_MS,
+    val label: String? = null,
+    val description: String? = null,
+)
+
+const val DEFAULT_TIMEOUT_MS = 120_000L
+

--- a/app/src/main/java/me/rerere/rikkahub/data/datastore/PreferencesStore.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/datastore/PreferencesStore.kt
@@ -443,6 +443,7 @@ data class Settings(
     val searchCommonOptions: SearchCommonOptions = SearchCommonOptions(),
     val searchServiceSelected: Int = 0,
     val mcpServers: List<McpServerConfig> = emptyList(),
+    val termuxWorkdir: String = "/data/data/com.termux/files/home",
     val webDavConfig: WebDavConfig = WebDavConfig(),
     val s3Config: S3Config = S3Config(),
     val ttsProviders: List<TTSProviderSetting> = DEFAULT_TTS_PROVIDERS,

--- a/app/src/main/java/me/rerere/rikkahub/data/model/Assistant.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/model/Assistant.kt
@@ -35,6 +35,7 @@ data class Assistant(
     val customBodies: List<CustomBody> = emptyList(),
     val mcpServers: Set<Uuid> = emptySet(),
     val localTools: List<LocalToolOption> = listOf(LocalToolOption.TimeInfo),
+    val termuxNeedsApproval: Boolean = true,
     val background: String? = null,
     val modeInjectionIds: Set<Uuid> = emptySet(),      // 关联的模式注入 ID
     val lorebookIds: Set<Uuid> = emptySet(),            // 关联的 Lorebook ID

--- a/app/src/main/java/me/rerere/rikkahub/di/AppModule.kt
+++ b/app/src/main/java/me/rerere/rikkahub/di/AppModule.kt
@@ -9,6 +9,7 @@ import me.rerere.highlight.Highlighter
 import me.rerere.rikkahub.AppScope
 import me.rerere.rikkahub.data.ai.AILoggingManager
 import me.rerere.rikkahub.data.ai.tools.LocalTools
+import me.rerere.rikkahub.data.ai.tools.termux.TermuxCommandManager
 import me.rerere.rikkahub.service.ChatService
 import me.rerere.rikkahub.utils.EmojiData
 import me.rerere.rikkahub.utils.EmojiUtils
@@ -26,7 +27,11 @@ val appModule = module {
     }
 
     single {
-        LocalTools(get())
+        TermuxCommandManager(get())
+    }
+
+    single {
+        LocalTools(get(), get(), get())
     }
 
     single {

--- a/app/src/main/java/me/rerere/rikkahub/service/ChatService.kt
+++ b/app/src/main/java/me/rerere/rikkahub/service/ChatService.kt
@@ -474,7 +474,8 @@ class ChatService(
                     if (settings.enableWebSearch) {
                         addAll(createSearchTools(settings))
                     }
-                    addAll(localTools.getTools(settings.getCurrentAssistant().localTools))
+                    val currentAssistant = settings.getCurrentAssistant()
+                    addAll(localTools.getTools(currentAssistant.localTools, currentAssistant))
                     mcpManager.getAllAvailableTools().forEach { tool ->
                         add(
                             Tool(

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/assistant/detail/AssistantLocalToolPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/assistant/detail/AssistantLocalToolPage.kt
@@ -115,6 +115,50 @@ private fun AssistantLocalToolContent(
                 onUpdate(assistant.copy(localTools = newLocalTools))
             }
         )
+
+        // Termux 命令工具卡片
+        LocalToolCard(
+            title = stringResource(R.string.assistant_page_local_tools_termux_exec_title),
+            description = stringResource(R.string.assistant_page_local_tools_termux_exec_desc),
+            isEnabled = assistant.localTools.contains(LocalToolOption.TermuxExec),
+            onToggle = { enabled ->
+                val newLocalTools = if (enabled) {
+                    assistant.localTools + LocalToolOption.TermuxExec
+                } else {
+                    assistant.localTools - LocalToolOption.TermuxExec
+                }
+                onUpdate(assistant.copy(localTools = newLocalTools))
+            }
+        )
+
+        // Termux Python 工具卡片
+        LocalToolCard(
+            title = stringResource(R.string.assistant_page_local_tools_termux_python_title),
+            description = stringResource(R.string.assistant_page_local_tools_termux_python_desc),
+            isEnabled = assistant.localTools.contains(LocalToolOption.TermuxPython),
+            onToggle = { enabled ->
+                val newLocalTools = if (enabled) {
+                    assistant.localTools + LocalToolOption.TermuxPython
+                } else {
+                    assistant.localTools - LocalToolOption.TermuxPython
+                }
+                onUpdate(assistant.copy(localTools = newLocalTools))
+            }
+        )
+
+        val termuxToolsEnabled = assistant.localTools.any {
+            it == LocalToolOption.TermuxExec || it == LocalToolOption.TermuxPython
+        }
+        if (termuxToolsEnabled) {
+            LocalToolCard(
+                title = stringResource(R.string.assistant_page_local_tools_termux_needs_approval_title),
+                description = stringResource(R.string.assistant_page_local_tools_termux_needs_approval_desc),
+                isEnabled = assistant.termuxNeedsApproval,
+                onToggle = { enabled ->
+                    onUpdate(assistant.copy(termuxNeedsApproval = enabled))
+                }
+            )
+        }
     }
 }
 

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingPage.kt
@@ -256,6 +256,16 @@ fun SettingPage(vm: SettingVM = koinViewModel()) {
             item {
                 SettingItem(
                     navController = navController,
+                    title = { Text(stringResource(R.string.setting_page_termux)) },
+                    description = { Text(stringResource(R.string.setting_page_termux_desc)) },
+                    icon = { Icon(Lucide.FolderOpen, "Termux") },
+                    link = Screen.SettingTermux
+                )
+            }
+
+            item {
+                SettingItem(
+                    navController = navController,
                     title = { Text(stringResource(R.string.setting_page_web_server)) },
                     description = { Text(stringResource(R.string.setting_page_web_server_desc)) },
                     icon = { Icon(Lucide.Globe, "Web Server") },

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingTermuxPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingTermuxPage.kt
@@ -1,0 +1,128 @@
+package me.rerere.rikkahub.ui.pages.setting
+
+import android.content.Intent
+import android.net.Uri
+import android.provider.Settings
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.LargeTopAppBar
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import kotlinx.coroutines.launch
+import me.rerere.rikkahub.R
+import me.rerere.rikkahub.data.datastore.SettingsStore
+import me.rerere.rikkahub.ui.components.nav.BackButton
+import me.rerere.rikkahub.ui.components.ui.FormItem
+import me.rerere.rikkahub.utils.plus
+import org.koin.compose.koinInject
+
+@Composable
+fun SettingTermuxPage() {
+    val settingsStore: SettingsStore = koinInject()
+    val settings by settingsStore.settingsFlow.collectAsStateWithLifecycle()
+    val scope = rememberCoroutineScope()
+    val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior()
+
+    var workdirText by remember(settings.termuxWorkdir) {
+        mutableStateOf(settings.termuxWorkdir)
+    }
+
+    val context = LocalContext.current
+
+    Scaffold(
+        topBar = {
+            LargeTopAppBar(
+                title = { Text(stringResource(R.string.setting_termux_page_title)) },
+                navigationIcon = { BackButton() },
+                scrollBehavior = scrollBehavior,
+            )
+        },
+        modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
+    ) { innerPadding ->
+        LazyColumn(
+            modifier = Modifier.fillMaxSize(),
+            contentPadding = innerPadding + PaddingValues(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            item("workdir") {
+                Card(
+                    colors = CardDefaults.cardColors(
+                        containerColor = MaterialTheme.colorScheme.surfaceContainerLow,
+                    ),
+                ) {
+                    FormItem(
+                        modifier = Modifier.padding(12.dp),
+                        label = { Text(stringResource(R.string.setting_termux_page_workdir_title)) },
+                        description = { Text(stringResource(R.string.setting_termux_page_workdir_desc)) },
+                        content = {
+                            OutlinedTextField(
+                                modifier = Modifier.fillMaxWidth(),
+                                value = workdirText,
+                                onValueChange = { value ->
+                                    workdirText = value
+                                    scope.launch {
+                                        settingsStore.update { it.copy(termuxWorkdir = value) }
+                                    }
+                                },
+                                singleLine = true,
+                            )
+                        },
+                    )
+                }
+            }
+
+            item("setup") {
+                Card(
+                    colors = CardDefaults.cardColors(
+                        containerColor = MaterialTheme.colorScheme.surfaceContainerLow,
+                    ),
+                ) {
+                    Column(modifier = Modifier.padding(12.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                        Text(
+                            text = stringResource(R.string.setting_termux_page_setup_title),
+                            style = MaterialTheme.typography.titleMedium,
+                        )
+                        Text(stringResource(R.string.setting_termux_page_setup_step_1))
+                        Text(stringResource(R.string.setting_termux_page_setup_step_2))
+                        Text(stringResource(R.string.setting_termux_page_setup_step_3))
+                        Text(stringResource(R.string.setting_termux_page_setup_step_4))
+                        TextButton(
+                            onClick = {
+                                val intent = Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply {
+                                    data = Uri.fromParts("package", context.packageName, null)
+                                }
+                                context.startActivity(intent)
+                            }
+                        ) {
+                            Text(stringResource(R.string.setting_termux_page_open_app_settings))
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -67,6 +67,12 @@
   <string name="assistant_page_local_tools_time_info_title">Time Info</string>
   <string name="assistant_page_local_tools_clipboard_desc">Read or write plain text from the device clipboard</string>
   <string name="assistant_page_local_tools_clipboard_title">Clipboard</string>
+  <string name="assistant_page_local_tools_termux_exec_title">Termux Command</string>
+  <string name="assistant_page_local_tools_termux_exec_desc">Execute commands in local Termux (com.termux) via the termux_exec tool</string>
+  <string name="assistant_page_local_tools_termux_python_title">Termux Python</string>
+  <string name="assistant_page_local_tools_termux_python_desc">Run Python code in Termux via the termux_python tool (requires Termux python)</string>
+  <string name="assistant_page_local_tools_termux_needs_approval_title">Require Approval</string>
+  <string name="assistant_page_local_tools_termux_needs_approval_desc">When enabled, Termux tools require manual approval before running</string>
   <string name="assistant_page_manage_memory_title">Manage Memory</string>
   <string name="assistant_page_max_tokens">Max Tokens</string>
   <string name="assistant_page_max_tokens_desc">Maximum number of tokens to generate. Leave empty for no limit.</string>
@@ -481,6 +487,8 @@
   <string name="setting_page_general_settings">General Settings</string>
   <string name="setting_page_mcp">MCP</string>
   <string name="setting_page_mcp_desc">Configure MCP Servers</string>
+  <string name="setting_page_termux">Termux</string>
+  <string name="setting_page_termux_desc">Configure local Termux tools (workdir, permissions)</string>
   <string name="setting_page_model_and_services">Models &amp; Services</string>
   <string name="setting_page_no_share_app">No sharing app found</string>
   <string name="setting_page_providers">Providers</string>
@@ -807,7 +815,15 @@
   <string name="setting_page_web_server_error">Error</string>
   <string name="setting_page_web_server_start">Start</string>
   <string name="setting_page_web_server_stop">Stop</string>
+  <string name="setting_termux_page_title">Termux</string>
+  <string name="setting_termux_page_workdir_title">Termux Workdir</string>
+  <string name="setting_termux_page_workdir_desc">Default working directory for termux_exec and termux_python (e.g. /data/data/com.termux/files/home/workspace)</string>
+  <string name="setting_termux_page_setup_title">Setup checklist</string>
+  <string name="setting_termux_page_setup_step_1">1) Install Termux (com.termux)</string>
+  <string name="setting_termux_page_setup_step_2">2) In Termux: set allow-external-apps=true in ~/.termux/termux.properties, then restart Termux</string>
+  <string name="setting_termux_page_setup_step_3">3) Android Settings: grant “Run commands in Termux environment” to this app (Additional permissions)</string>
+  <string name="setting_termux_page_setup_step_4">4) For termux_python: install Python in Termux (pkg install python)</string>
+  <string name="setting_termux_page_open_app_settings">Open App Settings</string>
   <string name="setting_display_page_enable_latex_rendering_title">Enable LaTeX Rendering</string>
   <string name="setting_display_page_enable_latex_rendering_desc">Render mathematical expressions and formulas using LaTeX syntax</string>
 </resources>
-

--- a/app/src/test/java/me/rerere/rikkahub/data/ai/tools/termux/TermuxProtocolTest.kt
+++ b/app/src/test/java/me/rerere/rikkahub/data/ai/tools/termux/TermuxProtocolTest.kt
@@ -1,0 +1,26 @@
+package me.rerere.rikkahub.data.ai.tools.termux
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class TermuxProtocolTest {
+    @Test
+    fun `constants match termux defaults`() {
+        assertEquals("com.termux", TermuxProtocol.TERMUX_PACKAGE_NAME)
+        assertEquals("com.termux.app.RunCommandService", TermuxProtocol.RUN_COMMAND_SERVICE)
+        assertEquals("com.termux.permission.RUN_COMMAND", TermuxProtocol.PERMISSION_RUN_COMMAND)
+        assertEquals("com.termux.RUN_COMMAND", TermuxProtocol.ACTION_RUN_COMMAND)
+        assertEquals("com.termux.RUN_COMMAND_PATH", TermuxProtocol.EXTRA_COMMAND_PATH)
+        assertEquals("com.termux.RUN_COMMAND_ARGUMENTS", TermuxProtocol.EXTRA_ARGUMENTS)
+        assertEquals("com.termux.RUN_COMMAND_WORKDIR", TermuxProtocol.EXTRA_WORKDIR)
+        assertEquals("com.termux.RUN_COMMAND_BACKGROUND", TermuxProtocol.EXTRA_BACKGROUND)
+        assertEquals("com.termux.RUN_COMMAND_PENDING_INTENT", TermuxProtocol.EXTRA_PENDING_INTENT)
+        assertEquals("result", TermuxProtocol.RESULT_BUNDLE)
+        assertEquals("stdout", TermuxProtocol.RESULT_STDOUT)
+        assertEquals("stderr", TermuxProtocol.RESULT_STDERR)
+        assertEquals("exitCode", TermuxProtocol.RESULT_EXIT_CODE)
+        assertEquals("err", TermuxProtocol.RESULT_ERR)
+        assertEquals("errmsg", TermuxProtocol.RESULT_ERRMSG)
+    }
+}
+


### PR DESCRIPTION
### What
- Add Termux RUN_COMMAND bridge (with PendingIntent result callback).
- New local tools: `termux_exec` (run any Termux command) and `termux_python` (paste Python code; prints last expression result).
- Global setting: Termux workdir (default `/data/data/com.termux/files/home`).
- Assistant-level toggle: require approval for Termux tools (default on).
- Tool output is returned as plain terminal text (stdout + stderr), matching Termux behavior.

### Requirements
- Install Termux (`com.termux`).
- In Termux: set `allow-external-apps=true` in `~/.termux/termux.properties`, then restart Termux.
- Android Settings: grant this app `com.termux.permission.RUN_COMMAND` (Additional permissions).
- For `termux_python`: install python in Termux (`pkg install python`).

### Notes
- Manifest: adds Termux permission + package visibility + callback service.
