### PR TITLE
修复 Termux 工具结果显示为 {} 并新增后台运行开关

### DIFF
--- a/app/src/main/java/me/rerere/rikkahub/data/ai/tools/LocalTools.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/ai/tools/LocalTools.kt
@@ -254,7 +254,11 @@ class LocalTools(
                         })
                         put("background", buildJsonObject {
                             put("type", "boolean")
-                            put("description", "Run as background command (recommended). Default true.")
+                            put(
+                                "description",
+                                "Run as background command. Default follows Settings -> Termux -> Run in background. " +
+                                    "If that setting is enabled, this is forced to true."
+                            )
                         })
                         put("timeout_ms", buildJsonObject {
                             put("type", "integer")
@@ -270,7 +274,12 @@ class LocalTools(
                 val stdin = params["stdin"]?.jsonPrimitive?.contentOrNull
                 val workdir = params["workdir"]?.jsonPrimitive?.contentOrNull?.takeIf { it.isNotBlank() }
                     ?: settingsStore.settingsFlow.value.termuxWorkdir
-                val background = params["background"]?.jsonPrimitive?.booleanOrNull ?: true
+                val requestedBackground = params["background"]?.jsonPrimitive?.booleanOrNull
+                val background = if (settingsStore.settingsFlow.value.termuxRunInBackground) {
+                    true
+                } else {
+                    requestedBackground ?: false
+                }
                 val timeoutMs = params["timeout_ms"]?.jsonPrimitive?.longOrNull ?: DEFAULT_TIMEOUT_MS
 
                 val (finalCommandPath, finalArgs) = if (command != null) {
@@ -377,7 +386,7 @@ class LocalTools(
                             arguments = listOf("-"),
                             workdir = workdir,
                             stdin = code,
-                            background = true,
+                            background = settingsStore.settingsFlow.value.termuxRunInBackground,
                             timeoutMs = timeoutMs,
                             label = "RikkaHub termux_python",
                         )

--- a/app/src/main/java/me/rerere/rikkahub/data/datastore/PreferencesStore.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/datastore/PreferencesStore.kt
@@ -102,6 +102,10 @@ class SettingsStore(
         // MCP
         val MCP_SERVERS = stringPreferencesKey("mcp_servers")
 
+        // Termux
+        val TERMUX_WORKDIR = stringPreferencesKey("termux_workdir")
+        val TERMUX_RUN_IN_BACKGROUND = booleanPreferencesKey("termux_run_in_background")
+
         // WebDAV
         val WEBDAV_CONFIG = stringPreferencesKey("webdav_config")
 
@@ -175,6 +179,8 @@ class SettingsStore(
                 mcpServers = preferences[MCP_SERVERS]?.let {
                     JsonInstant.decodeFromString(it)
                 } ?: emptyList(),
+                termuxWorkdir = preferences[TERMUX_WORKDIR] ?: "/data/data/com.termux/files/home",
+                termuxRunInBackground = preferences[TERMUX_RUN_IN_BACKGROUND] != false,
                 webDavConfig = preferences[WEBDAV_CONFIG]?.let {
                     JsonInstant.decodeFromString(it)
                 } ?: WebDavConfig(),
@@ -324,6 +330,8 @@ class SettingsStore(
             preferences[SEARCH_SELECTED] = settings.searchServiceSelected.coerceIn(0, settings.searchServices.size - 1)
 
             preferences[MCP_SERVERS] = JsonInstant.encodeToString(settings.mcpServers)
+            preferences[TERMUX_WORKDIR] = settings.termuxWorkdir
+            preferences[TERMUX_RUN_IN_BACKGROUND] = settings.termuxRunInBackground
             preferences[WEBDAV_CONFIG] = JsonInstant.encodeToString(settings.webDavConfig)
             preferences[S3_CONFIG] = JsonInstant.encodeToString(settings.s3Config)
             preferences[TTS_PROVIDERS] = JsonInstant.encodeToString(settings.ttsProviders)
@@ -444,6 +452,7 @@ data class Settings(
     val searchServiceSelected: Int = 0,
     val mcpServers: List<McpServerConfig> = emptyList(),
     val termuxWorkdir: String = "/data/data/com.termux/files/home",
+    val termuxRunInBackground: Boolean = true,
     val webDavConfig: WebDavConfig = WebDavConfig(),
     val s3Config: S3Config = S3Config(),
     val ttsProviders: List<TTSProviderSetting> = DEFAULT_TTS_PROVIDERS,

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingTermuxPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingTermuxPage.kt
@@ -16,6 +16,7 @@ import androidx.compose.material3.LargeTopAppBar
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBarDefaults
@@ -94,6 +95,30 @@ fun SettingTermuxPage() {
                 }
             }
 
+            item("background") {
+                Card(
+                    colors = CardDefaults.cardColors(
+                        containerColor = MaterialTheme.colorScheme.surfaceContainerLow,
+                    ),
+                ) {
+                    FormItem(
+                        modifier = Modifier.padding(12.dp),
+                        label = { Text(stringResource(R.string.setting_termux_page_background_title)) },
+                        description = { Text(stringResource(R.string.setting_termux_page_background_desc)) },
+                        tail = {
+                            Switch(
+                                checked = settings.termuxRunInBackground,
+                                onCheckedChange = { enabled ->
+                                    scope.launch {
+                                        settingsStore.update { it.copy(termuxRunInBackground = enabled) }
+                                    }
+                                },
+                            )
+                        },
+                    )
+                }
+            }
+
             item("setup") {
                 Card(
                     colors = CardDefaults.cardColors(
@@ -125,4 +150,3 @@ fun SettingTermuxPage() {
         }
     }
 }
-

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -809,5 +809,23 @@
   <string name="setting_page_web_server_password_desc">網頁介面存取所需的密碼</string>
   <string name="setting_display_page_enable_latex_rendering_title">啟用 LaTeX 渲染</string>
   <string name="setting_display_page_enable_latex_rendering_desc">使用 LaTeX 語法呈現數學表達式與公式</string>
+  <string name="assistant_page_local_tools_termux_exec_title">Termux 指令</string>
+  <string name="assistant_page_local_tools_termux_exec_desc">透過 termux_exec 工具在本機 Termux（com.termux）中執行指令</string>
+  <string name="assistant_page_local_tools_termux_python_title">Termux Python</string>
+  <string name="assistant_page_local_tools_termux_python_desc">透過 termux_python 工具在 Termux 中執行 Python 程式碼（需在 Termux 中安裝 Python）</string>
+  <string name="assistant_page_local_tools_termux_needs_approval_title">需要審批</string>
+  <string name="assistant_page_local_tools_termux_needs_approval_desc">啟用後，執行 Termux 工具前需要手動審批</string>
+  <string name="setting_page_termux">Termux</string>
+  <string name="setting_page_termux_desc">設定本機 Termux 工具（工作目錄、權限）</string>
+  <string name="setting_termux_page_title">Termux</string>
+  <string name="setting_termux_page_workdir_title">Termux 工作目錄</string>
+  <string name="setting_termux_page_workdir_desc">termux_exec 與 termux_python 的預設工作目錄（例如 /data/data/com.termux/files/home/workspace）</string>
+  <string name="setting_termux_page_background_title">背景執行</string>
+  <string name="setting_termux_page_background_desc">讓 Termux 工具在背景執行，不自動切換到 Termux 前景（推薦）</string>
+  <string name="setting_termux_page_setup_title">設定清單</string>
+  <string name="setting_termux_page_setup_step_1">1）安裝 Termux（com.termux）</string>
+  <string name="setting_termux_page_setup_step_2">2）在 Termux 中：在 ~/.termux/termux.properties 設定 allow-external-apps=true，然後重新啟動 Termux</string>
+  <string name="setting_termux_page_setup_step_3">3）在系統設定中：為本應用程式授予「在 Termux 環境中執行命令」權限（額外權限）</string>
+  <string name="setting_termux_page_setup_step_4">4）若使用 termux_python：在 Termux 中安裝 Python（pkg install python）</string>
+  <string name="setting_termux_page_open_app_settings">開啟應用程式設定</string>
 </resources>
-

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -809,5 +809,23 @@
   <string name="setting_page_web_server_password_desc">网页界面访问所需的密码</string>
   <string name="setting_display_page_enable_latex_rendering_title">启用 LaTeX 渲染</string>
   <string name="setting_display_page_enable_latex_rendering_desc">使用 LaTeX 语法渲染数学表达式和公式</string>
+  <string name="assistant_page_local_tools_termux_exec_title">Termux 命令</string>
+  <string name="assistant_page_local_tools_termux_exec_desc">通过 termux_exec 工具在本地 Termux（com.termux）中执行命令</string>
+  <string name="assistant_page_local_tools_termux_python_title">Termux Python</string>
+  <string name="assistant_page_local_tools_termux_python_desc">通过 termux_python 工具在 Termux 中运行 Python 代码（需在 Termux 中安装 Python）</string>
+  <string name="assistant_page_local_tools_termux_needs_approval_title">需要审批</string>
+  <string name="assistant_page_local_tools_termux_needs_approval_desc">启用后，运行 Termux 工具前需要手动审批</string>
+  <string name="setting_page_termux">Termux</string>
+  <string name="setting_page_termux_desc">配置本地 Termux 工具（工作目录、权限）</string>
+  <string name="setting_termux_page_title">Termux</string>
+  <string name="setting_termux_page_workdir_title">Termux 工作目录</string>
+  <string name="setting_termux_page_workdir_desc">termux_exec 与 termux_python 的默认工作目录（例如 /data/data/com.termux/files/home/workspace）</string>
+  <string name="setting_termux_page_background_title">后台运行</string>
+  <string name="setting_termux_page_background_desc">让 Termux 工具在后台执行，不自动切换到 Termux 前台（推荐）</string>
+  <string name="setting_termux_page_setup_title">设置清单</string>
+  <string name="setting_termux_page_setup_step_1">1）安装 Termux（com.termux）</string>
+  <string name="setting_termux_page_setup_step_2">2）在 Termux 中：在 ~/.termux/termux.properties 设置 allow-external-apps=true，然后重启 Termux</string>
+  <string name="setting_termux_page_setup_step_3">3）在系统设置中：为本应用授予“在 Termux 环境中运行命令”权限（额外权限）</string>
+  <string name="setting_termux_page_setup_step_4">4）若使用 termux_python：在 Termux 中安装 Python（pkg install python）</string>
+  <string name="setting_termux_page_open_app_settings">打开应用设置</string>
 </resources>
-

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -818,6 +818,8 @@
   <string name="setting_termux_page_title">Termux</string>
   <string name="setting_termux_page_workdir_title">Termux Workdir</string>
   <string name="setting_termux_page_workdir_desc">Default working directory for termux_exec and termux_python (e.g. /data/data/com.termux/files/home/workspace)</string>
+  <string name="setting_termux_page_background_title">Run in background</string>
+  <string name="setting_termux_page_background_desc">Execute Termux tools in background without bringing Termux to the foreground (recommended)</string>
   <string name="setting_termux_page_setup_title">Setup checklist</string>
   <string name="setting_termux_page_setup_step_1">1) Install Termux (com.termux)</string>
   <string name="setting_termux_page_setup_step_2">2) In Termux: set allow-external-apps=true in ~/.termux/termux.properties, then restart Termux</string>


### PR DESCRIPTION
- 修复：当工具输出不是 JSON（如 Termux stdout/stderr）时，Android/Web UI 不再只显示 "{}"，改为回退展示原始文本。\n- 新增：设置 -> Termux -> 后台运行（默认开启），开启时强制 Termux 工具以 background=true 执行，避免频繁切换到 Termux 前台。\n- 持久化：termuxWorkdir 与后台开关写入 DataStore。\n- 汉化：补齐 Termux 工具/设置相关简中与繁中字符串。\n\n验证：\n- npm -C web-ui run typecheck\n- ./gradlew :app:compileDebugKotlin -x :app:processDebugGoogleServices