### PR TITLE
fix: resolve html preview density and webview data reload edge cases

### DIFF
--- a/app/src/main/java/me/rerere/rikkahub/ui/components/richtext/HtmlCodeBlockPreview.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/richtext/HtmlCodeBlockPreview.kt
@@ -8,7 +8,7 @@ import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.dp
 import me.rerere.rikkahub.ui.components.webview.WebView
 import me.rerere.rikkahub.ui.components.webview.rememberWebViewState
 import kotlin.math.max
@@ -19,9 +19,9 @@ private val FULL_HTML_DOCUMENT_TAG_REGEX = Regex(
 )
 
 private const val HTML_PREVIEW_BRIDGE_NAME = "RikkaHtmlPreview"
-private const val DEFAULT_PREVIEW_HEIGHT_PX = 220
-private const val MIN_PREVIEW_HEIGHT_PX = 120
-private const val MAX_PREVIEW_HEIGHT_PX = 900
+private const val DEFAULT_PREVIEW_HEIGHT_DP = 220
+private const val MIN_PREVIEW_HEIGHT_DP = 120
+private const val MAX_PREVIEW_HEIGHT_DP = 900
 
 private const val INSTALL_HEIGHT_OBSERVER_SCRIPT = """
 (function () {
@@ -101,19 +101,18 @@ fun HtmlCodeBlockPreview(
     htmlCode: String,
     modifier: Modifier = Modifier,
 ) {
-    val density = LocalDensity.current
-    var contentHeightPx by remember(htmlCode) { mutableIntStateOf(DEFAULT_PREVIEW_HEIGHT_PX) }
+    var contentHeightDp by remember(htmlCode) { mutableIntStateOf(DEFAULT_PREVIEW_HEIGHT_DP) }
 
     val jsInterface = remember(htmlCode) {
         HtmlCodeBlockPreviewBridge(
             onHeightChanged = { height ->
-                contentHeightPx = height.coerceIn(MIN_PREVIEW_HEIGHT_PX, MAX_PREVIEW_HEIGHT_PX)
+                contentHeightDp = height.coerceIn(MIN_PREVIEW_HEIGHT_DP, MAX_PREVIEW_HEIGHT_DP)
             }
         )
     }
 
     val htmlDocument = remember(htmlCode) { buildHtmlPreviewDocument(htmlCode) }
-    val previewHeight = with(density) { max(contentHeightPx, MIN_PREVIEW_HEIGHT_PX).toDp() }
+    val previewHeight = max(contentHeightDp, MIN_PREVIEW_HEIGHT_DP).dp
 
     WebView(
         state = rememberWebViewState(

--- a/app/src/main/java/me/rerere/rikkahub/ui/components/webview/WebView.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/webview/WebView.kt
@@ -126,7 +126,7 @@ fun WebView(
 
                 when (val content = state.content) {
                     is WebContent.Url -> {
-                        state.lastLoadedDataSignature = null
+                        state.lastLoadedData = null
                         val url = content.url
                         // Only load new URL if it's different from the current one or if the state forces reload
                         // Also check if the webView's url is null or blank, which might happen initially
@@ -138,8 +138,7 @@ fun WebView(
                     }
 
                     is WebContent.Data -> {
-                        val signature = content.hashCode()
-                        if (state.forceReload || state.lastLoadedDataSignature != signature) {
+                        if (state.forceReload || state.lastLoadedData != content) {
                             webView.loadDataWithBaseURL(
                                 content.baseUrl,
                                 content.data,
@@ -147,7 +146,7 @@ fun WebView(
                                 content.encoding,
                                 content.historyUrl
                             )
-                            state.lastLoadedDataSignature = signature
+                            state.lastLoadedData = content
                             state.forceReload = false
                         }
                     }
@@ -223,7 +222,7 @@ class WebViewState(
 
     // --- Settings ---
     var javaScriptEnabled: Boolean by mutableStateOf(true) // Example setting
-    internal var lastLoadedDataSignature: Int? = null
+    internal var lastLoadedData: WebContent.Data? = null
 
     // --- WebView Instance ---
     // Hold the WebView instance internally to perform actions.


### PR DESCRIPTION
## Summary
- treat JS-reported HTML preview height as dp/CSS px to avoid density double-conversion and clipping on high-density devices
- replace hash-only WebContent.Data reload dedupe with direct WebContent.Data equality checks
- keep URL-content transition logic resetting cached Data content marker

## Verification
- ./gradlew :app:compileDebugKotlin