### PR TITLE
Add local skills catalog integration

### DIFF
--- a/app/src/main/java/me/rerere/rikkahub/RouteActivity.kt
+++ b/app/src/main/java/me/rerere/rikkahub/RouteActivity.kt
@@ -78,6 +78,7 @@ import me.rerere.rikkahub.ui.pages.assistant.detail.AssistantMcpPage
 import me.rerere.rikkahub.ui.pages.assistant.detail.AssistantMemoryPage
 import me.rerere.rikkahub.ui.pages.assistant.detail.AssistantPromptPage
 import me.rerere.rikkahub.ui.pages.assistant.detail.AssistantRequestPage
+import me.rerere.rikkahub.ui.pages.assistant.detail.AssistantSkillsPage
 import me.rerere.rikkahub.ui.pages.backup.BackupPage
 import me.rerere.rikkahub.ui.pages.chat.ChatPage
 import me.rerere.rikkahub.ui.pages.debug.DebugPage
@@ -423,6 +424,10 @@ class RouteActivity : ComponentActivity() {
                                 AssistantLocalToolPage(key.id)
                             }
 
+                            entry<Screen.AssistantSkills> { key ->
+                                AssistantSkillsPage(key.id)
+                            }
+
                             entry<Screen.AssistantInjections> { key ->
                                 AssistantInjectionsPage(key.id)
                             }
@@ -625,6 +630,9 @@ sealed interface Screen : NavKey {
 
     @Serializable
     data class AssistantLocalTool(val id: String) : Screen
+
+    @Serializable
+    data class AssistantSkills(val id: String) : Screen
 
     @Serializable
     data class AssistantInjections(val id: String) : Screen

--- a/app/src/main/java/me/rerere/rikkahub/data/ai/GenerationHandler.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/ai/GenerationHandler.kt
@@ -41,6 +41,8 @@ import me.rerere.rikkahub.data.datastore.findModelById
 import me.rerere.rikkahub.data.datastore.findProvider
 import me.rerere.rikkahub.data.model.Assistant
 import me.rerere.rikkahub.data.model.AssistantMemory
+import me.rerere.rikkahub.data.skills.SkillsRepository
+import me.rerere.rikkahub.data.skills.buildSkillsCatalogPrompt
 import me.rerere.rikkahub.data.repository.ConversationRepository
 import me.rerere.rikkahub.data.repository.MemoryRepository
 import me.rerere.rikkahub.utils.applyPlaceholders
@@ -68,6 +70,7 @@ class GenerationHandler(
     private val memoryRepo: MemoryRepository,
     private val conversationRepo: ConversationRepository,
     private val aiLoggingManager: AILoggingManager,
+    private val skillsRepository: SkillsRepository,
 ) {
     fun generateText(
         settings: Settings,
@@ -345,6 +348,15 @@ class GenerationHandler(
                 if (assistant.enableRecentChatsReference) {
                     appendLine()
                     append(buildRecentChatsPrompt(assistant, conversationRepo))
+                }
+
+                buildSkillsCatalogPrompt(
+                    assistant = assistant,
+                    model = model,
+                    catalog = skillsRepository.state.value,
+                )?.let {
+                    appendLine()
+                    append(it)
                 }
 
                 // 工具prompt

--- a/app/src/main/java/me/rerere/rikkahub/data/model/Assistant.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/model/Assistant.kt
@@ -39,6 +39,8 @@ data class Assistant(
     val mcpServers: Set<Uuid> = emptySet(),
     val localTools: List<LocalToolOption> = listOf(LocalToolOption.TimeInfo),
     val localToolPrompts: Map<String, String> = emptyMap(),
+    val skillsEnabled: Boolean = false,
+    val selectedSkills: Set<String> = emptySet(),
     val termuxNeedsApproval: Boolean = true,
     val background: String? = null,
     val backgroundOpacity: Float = 1.0f,

--- a/app/src/main/java/me/rerere/rikkahub/data/skills/SkillsPrompt.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/skills/SkillsPrompt.kt
@@ -1,0 +1,47 @@
+package me.rerere.rikkahub.data.skills
+
+import me.rerere.ai.provider.Model
+import me.rerere.ai.provider.ModelAbility
+import me.rerere.rikkahub.data.ai.tools.LocalToolOption
+import me.rerere.rikkahub.data.model.Assistant
+
+internal fun shouldInjectSkillsCatalog(
+    assistant: Assistant,
+    model: Model,
+): Boolean {
+    return assistant.skillsEnabled &&
+        assistant.selectedSkills.isNotEmpty() &&
+        assistant.localTools.contains(LocalToolOption.TermuxExec) &&
+        model.abilities.contains(ModelAbility.TOOL)
+}
+
+internal fun buildSkillsCatalogPrompt(
+    assistant: Assistant,
+    model: Model,
+    catalog: SkillsCatalogState,
+): String? {
+    if (!shouldInjectSkillsCatalog(assistant, model)) return null
+    if (catalog.rootPath.isBlank()) return null
+
+    val selectedEntries = catalog.entries
+        .filter { it.directoryName in assistant.selectedSkills }
+        .sortedBy { it.directoryName }
+
+    if (selectedEntries.isEmpty()) return null
+
+    return buildString {
+        appendLine("Local skills are available in the Termux workdir.")
+        appendLine("Skills root: ${catalog.rootPath}")
+        appendLine("Each skill is a directory package. Only inspect a skill when it is relevant to the user's request.")
+        appendLine("Do not read every SKILL.md preemptively.")
+        appendLine("When a skill is relevant, use the existing Termux tools to inspect files such as SKILL.md or run scripts inside that skill directory.")
+        appendLine()
+        appendLine("Available skills:")
+        selectedEntries.forEach { skill ->
+            appendLine("- directory: ${skill.directoryName}")
+            appendLine("  name: ${skill.name}")
+            appendLine("  description: ${skill.description}")
+            appendLine("  path: ${skill.path}")
+        }
+    }.trim()
+}

--- a/app/src/main/java/me/rerere/rikkahub/data/skills/SkillsRepository.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/skills/SkillsRepository.kt
@@ -1,0 +1,311 @@
+package me.rerere.rikkahub.data.skills
+
+import android.util.Log
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import me.rerere.rikkahub.AppScope
+import me.rerere.rikkahub.data.ai.tools.termux.TermuxCommandManager
+import me.rerere.rikkahub.data.ai.tools.termux.TermuxRunCommandRequest
+import me.rerere.rikkahub.data.ai.tools.termux.isSuccessful
+import me.rerere.rikkahub.data.datastore.SettingsStore
+
+private const val TAG = "SkillsRepository"
+private const val TERMUX_BASH_PATH = "/data/data/com.termux/files/usr/bin/bash"
+
+data class SkillCatalogEntry(
+    val directoryName: String,
+    val path: String,
+    val name: String,
+    val description: String,
+)
+
+data class SkillInvalidEntry(
+    val directoryName: String,
+    val path: String,
+    val reason: String,
+)
+
+data class SkillsCatalogState(
+    val workdir: String = "",
+    val rootPath: String = "",
+    val entries: List<SkillCatalogEntry> = emptyList(),
+    val invalidEntries: List<SkillInvalidEntry> = emptyList(),
+    val isLoading: Boolean = false,
+    val error: String? = null,
+    val refreshedAt: Long = 0L,
+) {
+    val entryNames: Set<String> = entries.mapTo(linkedSetOf()) { it.directoryName }
+}
+
+internal data class SkillFrontmatter(
+    val name: String,
+    val description: String,
+)
+
+internal sealed interface SkillFrontmatterParseResult {
+    data class Success(val frontmatter: SkillFrontmatter) : SkillFrontmatterParseResult
+    data class Error(val reason: String) : SkillFrontmatterParseResult
+}
+
+class SkillsRepository(
+    private val appScope: AppScope,
+    private val settingsStore: SettingsStore,
+    private val termuxCommandManager: TermuxCommandManager,
+) {
+    private val refreshMutex = Mutex()
+    private val _state = MutableStateFlow(SkillsCatalogState())
+    val state: StateFlow<SkillsCatalogState> = _state.asStateFlow()
+
+    init {
+        appScope.launch {
+            settingsStore.settingsFlow
+                .map { it.termuxWorkdir }
+                .distinctUntilChanged()
+                .collect { workdir ->
+                    refresh(workdir)
+                }
+        }
+    }
+
+    fun requestRefresh() {
+        appScope.launch {
+            refresh(settingsStore.settingsFlow.value.termuxWorkdir)
+        }
+    }
+
+    suspend fun refresh(workdir: String = settingsStore.settingsFlow.value.termuxWorkdir) {
+        refreshMutex.withLock {
+            val rootPath = buildSkillsRootPath(workdir)
+            _state.value = _state.value.copy(
+                workdir = workdir,
+                rootPath = rootPath,
+                isLoading = true,
+                error = null,
+            )
+            _state.value = runCatching {
+                discover(workdir = workdir, rootPath = rootPath)
+            }.getOrElse { error ->
+                Log.w(TAG, "refresh failed for $rootPath", error)
+                SkillsCatalogState(
+                    workdir = workdir,
+                    rootPath = rootPath,
+                    entries = emptyList(),
+                    invalidEntries = emptyList(),
+                    isLoading = false,
+                    error = error.message ?: error.javaClass.name,
+                    refreshedAt = System.currentTimeMillis(),
+                )
+            }
+        }
+    }
+
+    private suspend fun discover(
+        workdir: String,
+        rootPath: String,
+    ): SkillsCatalogState {
+        val listed = listSkillDirectories(rootPath)
+        val validEntries = arrayListOf<SkillCatalogEntry>()
+        val invalidEntries = arrayListOf<SkillInvalidEntry>()
+
+        listed.forEach { directory ->
+            if (!directory.hasSkillFile) {
+                invalidEntries += SkillInvalidEntry(
+                    directoryName = directory.directoryName,
+                    path = directory.path,
+                    reason = "Missing SKILL.md",
+                )
+                return@forEach
+            }
+
+            val markdown = readSkillFile(directory.path)
+            when (val parsed = parseSkillFrontmatter(markdown)) {
+                is SkillFrontmatterParseResult.Success -> {
+                    validEntries += SkillCatalogEntry(
+                        directoryName = directory.directoryName,
+                        path = directory.path,
+                        name = parsed.frontmatter.name,
+                        description = parsed.frontmatter.description,
+                    )
+                }
+
+                is SkillFrontmatterParseResult.Error -> {
+                    invalidEntries += SkillInvalidEntry(
+                        directoryName = directory.directoryName,
+                        path = directory.path,
+                        reason = parsed.reason,
+                    )
+                }
+            }
+        }
+
+        return SkillsCatalogState(
+            workdir = workdir,
+            rootPath = rootPath,
+            entries = validEntries.sortedBy { it.directoryName },
+            invalidEntries = invalidEntries.sortedBy { it.directoryName },
+            isLoading = false,
+            error = null,
+            refreshedAt = System.currentTimeMillis(),
+        )
+    }
+
+    private suspend fun listSkillDirectories(rootPath: String): List<DiscoveredSkillDirectory> {
+        val script = buildListScript(rootPath)
+        val result = termuxCommandManager.run(
+            TermuxRunCommandRequest(
+                commandPath = TERMUX_BASH_PATH,
+                arguments = listOf("-lc", script),
+                workdir = settingsStore.settingsFlow.value.termuxWorkdir,
+                background = false,
+                timeoutMs = 30_000L,
+                label = "RikkaHub list local skills",
+            )
+        )
+        if (!result.isSuccessful()) {
+            error(result.errMsg.orEmpty().ifBlank { result.stderr.orEmpty().ifBlank { "Failed to list skills" } })
+        }
+        return result.stdout
+            .lineSequence()
+            .map { it.trim() }
+            .filter { it.isNotBlank() }
+            .mapNotNull { line ->
+                val parts = line.split('\t')
+                if (parts.size < 3) return@mapNotNull null
+                DiscoveredSkillDirectory(
+                    directoryName = parts[0],
+                    path = parts[1],
+                    hasSkillFile = parts[2] == "1",
+                )
+            }
+            .toList()
+    }
+
+    private suspend fun readSkillFile(directoryPath: String): String {
+        val script = buildReadSkillScript(directoryPath)
+        val result = termuxCommandManager.run(
+            TermuxRunCommandRequest(
+                commandPath = TERMUX_BASH_PATH,
+                arguments = listOf("-lc", script),
+                workdir = settingsStore.settingsFlow.value.termuxWorkdir,
+                background = false,
+                timeoutMs = 30_000L,
+                label = "RikkaHub read local skill",
+            )
+        )
+        if (!result.isSuccessful()) {
+            error(result.errMsg.orEmpty().ifBlank { result.stderr.orEmpty().ifBlank { "Failed to read SKILL.md" } })
+        }
+        return result.stdout
+    }
+
+    private fun buildListScript(rootPath: String): String {
+        val safeRoot = rootPath.escapeForSingleQuotedShell()
+        return """
+            set -eu
+            ROOT='$safeRoot'
+            if [ ! -d "${'$'}ROOT" ]; then
+              exit 0
+            fi
+            find "${'$'}ROOT" -mindepth 1 -maxdepth 1 -type d | sort | while IFS= read -r dir; do
+              [ -n "${'$'}dir" ] || continue
+              name="${'$'}(basename "${'$'}dir")"
+              if [ -f "${'$'}dir/SKILL.md" ]; then
+                printf '%s\t%s\t1\n' "${'$'}name" "${'$'}dir"
+              else
+                printf '%s\t%s\t0\n' "${'$'}name" "${'$'}dir"
+              fi
+            done
+        """.trimIndent()
+    }
+
+    private fun buildReadSkillScript(directoryPath: String): String {
+        val safeDirectory = directoryPath.escapeForSingleQuotedShell()
+        return """
+            set -eu
+            DIR='$safeDirectory'
+            cat "${'$'}DIR/SKILL.md"
+        """.trimIndent()
+    }
+
+    companion object {
+        fun buildSkillsRootPath(workdir: String): String {
+            val normalized = workdir.trimEnd('/').ifBlank { "/data/data/com.termux/files/home" }
+            return "$normalized/skills"
+        }
+    }
+}
+
+internal fun parseSkillFrontmatter(markdown: String): SkillFrontmatterParseResult {
+    val normalized = markdown.trimStart()
+    if (!normalized.startsWith("---")) {
+        return SkillFrontmatterParseResult.Error("SKILL.md is missing YAML frontmatter")
+    }
+
+    val lines = normalized.lineSequence().toList()
+    if (lines.isEmpty() || lines.first().trim() != "---") {
+        return SkillFrontmatterParseResult.Error("SKILL.md frontmatter must start with ---")
+    }
+
+    val endIndex = lines.indexOfFirst { indexLine ->
+        indexLine.trim() == "---"
+    }.let { firstEnd ->
+        if (firstEnd <= 0) {
+            lines.drop(1).indexOfFirst { it.trim() == "---" }.let { relative ->
+                if (relative >= 0) relative + 1 else -1
+            }
+        } else {
+            firstEnd
+        }
+    }
+
+    if (endIndex <= 0) {
+        return SkillFrontmatterParseResult.Error("SKILL.md frontmatter is not closed")
+    }
+
+    val values = linkedMapOf<String, String>()
+    lines.subList(1, endIndex).forEach { rawLine ->
+        val line = rawLine.trim()
+        if (line.isBlank() || line.startsWith("#")) return@forEach
+        val separator = line.indexOf(':')
+        if (separator <= 0) return@forEach
+        val key = line.substring(0, separator).trim()
+        val value = line.substring(separator + 1).trim().trimMatchingQuotes()
+        if (key.isNotBlank()) {
+            values[key] = value
+        }
+    }
+
+    val name = values["name"]?.takeIf { it.isNotBlank() }
+        ?: return SkillFrontmatterParseResult.Error("SKILL.md frontmatter is missing name")
+    val description = values["description"]?.takeIf { it.isNotBlank() }
+        ?: return SkillFrontmatterParseResult.Error("SKILL.md frontmatter is missing description")
+
+    return SkillFrontmatterParseResult.Success(
+        SkillFrontmatter(
+            name = name,
+            description = description,
+        )
+    )
+}
+
+private data class DiscoveredSkillDirectory(
+    val directoryName: String,
+    val path: String,
+    val hasSkillFile: Boolean,
+)
+
+private fun String.escapeForSingleQuotedShell(): String = replace("'", "'\"'\"'")
+
+private fun String.trimMatchingQuotes(): String {
+    if (length >= 2 && first() == last() && (first() == '"' || first() == '\'')) {
+        return substring(1, lastIndex)
+    }
+    return this
+}

--- a/app/src/main/java/me/rerere/rikkahub/di/AppModule.kt
+++ b/app/src/main/java/me/rerere/rikkahub/di/AppModule.kt
@@ -13,6 +13,7 @@ import me.rerere.rikkahub.data.ai.tools.termux.TermuxCommandManager
 import me.rerere.rikkahub.data.ai.tools.termux.TermuxPtySessionManager
 import me.rerere.rikkahub.data.ai.tools.termux.TermuxWorkdirServerManager
 import me.rerere.rikkahub.data.event.AppEventBus
+import me.rerere.rikkahub.data.skills.SkillsRepository
 import me.rerere.rikkahub.service.ChatService
 import me.rerere.rikkahub.service.ScheduledPromptManager
 import me.rerere.rikkahub.service.ScheduledPromptWorker
@@ -59,6 +60,14 @@ val appModule = module {
 
     single {
         LocalTools(get(), get(), get(), get(), get(), get())
+    }
+
+    single {
+        SkillsRepository(
+            appScope = get(),
+            settingsStore = get(),
+            termuxCommandManager = get(),
+        )
     }
 
     single {

--- a/app/src/main/java/me/rerere/rikkahub/di/DataSourceModule.kt
+++ b/app/src/main/java/me/rerere/rikkahub/di/DataSourceModule.kt
@@ -159,7 +159,8 @@ val dataSourceModule = module {
             json = get(),
             memoryRepo = get(),
             conversationRepo = get(),
-            aiLoggingManager = get()
+            aiLoggingManager = get(),
+            skillsRepository = get(),
         )
     }
 

--- a/app/src/main/java/me/rerere/rikkahub/di/ViewModelModule.kt
+++ b/app/src/main/java/me/rerere/rikkahub/di/ViewModelModule.kt
@@ -44,6 +44,7 @@ val viewModelModule = module {
             settingsStore = get(),
             memoryRepository = get(),
             filesManager = get(),
+            skillsRepository = get(),
         )
     }
     viewModelOf(::TranslatorVM)

--- a/app/src/main/java/me/rerere/rikkahub/ui/components/ai/ChatInput.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/ai/ChatInput.kt
@@ -120,6 +120,7 @@ import me.rerere.rikkahub.R
 import me.rerere.rikkahub.Screen
 import me.rerere.rikkahub.data.ai.mcp.McpManager
 import me.rerere.rikkahub.data.datastore.Settings
+import me.rerere.rikkahub.data.datastore.findModelById
 import me.rerere.rikkahub.data.datastore.findProvider
 import me.rerere.rikkahub.data.datastore.getCurrentAssistant
 import me.rerere.rikkahub.data.datastore.getCurrentChatModel
@@ -262,7 +263,8 @@ fun ChatInput(
                             // Search
                             val enableSearchMsg = stringResource(R.string.web_search_enabled)
                             val disableSearchMsg = stringResource(R.string.web_search_disabled)
-                            val chatModel = settings.getCurrentChatModel()
+                            val effectiveChatModel = assistant.chatModelId?.let { settings.findModelById(it) }
+                                ?: settings.getCurrentChatModel()
                             SearchPickerButton(
                                 enableSearch = enableSearch,
                                 settings = settings,
@@ -279,11 +281,11 @@ fun ChatInput(
                                     )
                                 },
                                 onUpdateSearchService = onUpdateSearchService,
-                                model = chatModel,
+                                model = effectiveChatModel,
                             )
 
                             // Reasoning
-                            val model = settings.getCurrentChatModel()
+                            val model = effectiveChatModel
                             if (model?.abilities?.contains(ModelAbility.REASONING) == true) {
                                 ReasoningButton(
                                     reasoningTokens = assistant.thinkingBudget ?: 0,
@@ -301,6 +303,14 @@ fun ChatInput(
                             // Local Tools
                             LocalToolsPickerButton(
                                 assistant = assistant,
+                                onUpdateAssistant = {
+                                    onUpdateAssistant(it)
+                                },
+                            )
+
+                            SkillsPickerButton(
+                                assistant = assistant,
+                                modelSupportsTools = model?.abilities?.contains(ModelAbility.TOOL) == true,
                                 onUpdateAssistant = {
                                     onUpdateAssistant(it)
                                 },

--- a/app/src/main/java/me/rerere/rikkahub/ui/components/ai/SkillsPicker.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/ai/SkillsPicker.kt
@@ -1,0 +1,482 @@
+package me.rerere.rikkahub.ui.components.ai
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Badge
+import androidx.compose.material3.BadgedBox
+import androidx.compose.material3.Card
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import me.rerere.hugeicons.HugeIcons
+import me.rerere.hugeicons.stroke.Alert01
+import me.rerere.hugeicons.stroke.Package01
+import me.rerere.rikkahub.data.ai.tools.LocalToolOption
+import me.rerere.rikkahub.data.model.Assistant
+import me.rerere.rikkahub.data.skills.SkillCatalogEntry
+import me.rerere.rikkahub.data.skills.SkillInvalidEntry
+import me.rerere.rikkahub.data.skills.SkillsCatalogState
+import me.rerere.rikkahub.data.skills.SkillsRepository
+import me.rerere.rikkahub.ui.components.ui.ToggleSurface
+import org.koin.compose.koinInject
+
+@Composable
+fun SkillsPickerButton(
+    assistant: Assistant,
+    modelSupportsTools: Boolean,
+    modifier: Modifier = Modifier,
+    onUpdateAssistant: (Assistant) -> Unit,
+) {
+    val skillsRepository = koinInject<SkillsRepository>()
+    val skillsState by skillsRepository.state.collectAsStateWithLifecycle()
+    var showPicker by remember { mutableStateOf(false) }
+    val enabledCount = if (assistant.skillsEnabled) {
+        assistant.selectedSkills.count { it in skillsState.entryNames }
+    } else {
+        0
+    }
+
+    LaunchedEffect(showPicker) {
+        if (showPicker) {
+            skillsRepository.requestRefresh()
+        }
+    }
+
+    ToggleSurface(
+        modifier = modifier,
+        checked = assistant.skillsEnabled,
+        onClick = {
+            showPicker = true
+        },
+    ) {
+        Row(
+            modifier = Modifier.padding(vertical = 8.dp, horizontal = 8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            Box(
+                modifier = Modifier.size(24.dp),
+                contentAlignment = Alignment.Center,
+            ) {
+                if (skillsState.isLoading) {
+                    CircularProgressIndicator(modifier = Modifier.size(20.dp))
+                } else {
+                    BadgedBox(
+                        badge = {
+                            if (enabledCount > 0) {
+                                Badge(containerColor = MaterialTheme.colorScheme.tertiaryContainer) {
+                                    Text(text = enabledCount.toString())
+                                }
+                            }
+                        }
+                    ) {
+                        Icon(
+                            imageVector = HugeIcons.Package01,
+                            contentDescription = "Skills",
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    if (showPicker) {
+        ModalBottomSheet(
+            onDismissRequest = { showPicker = false },
+            sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .fillMaxHeight(0.7f)
+                    .padding(16.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(16.dp),
+            ) {
+                Text(
+                    text = "Skills",
+                    style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold),
+                )
+                SkillsPicker(
+                    assistant = assistant,
+                    skillsState = skillsState,
+                    modelSupportsTools = modelSupportsTools,
+                    onRefresh = skillsRepository::requestRefresh,
+                    onUpdateAssistant = onUpdateAssistant,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .weight(1f),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+fun SkillsPicker(
+    assistant: Assistant,
+    skillsState: SkillsCatalogState,
+    modelSupportsTools: Boolean,
+    onRefresh: () -> Unit,
+    onUpdateAssistant: (Assistant) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val termuxToolEnabled = assistant.localTools.contains(LocalToolOption.TermuxExec)
+    val missingSelections = remember(assistant.selectedSkills, skillsState.entryNames) {
+        assistant.selectedSkills
+            .filterNot { it in skillsState.entryNames }
+            .sorted()
+    }
+
+    LazyColumn(
+        modifier = modifier.fillMaxSize(),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        item("controls") {
+            Card {
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp, vertical = 12.dp),
+                    verticalArrangement = Arrangement.spacedBy(12.dp),
+                ) {
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(12.dp),
+                    ) {
+                        Column(
+                            modifier = Modifier.weight(1f),
+                            verticalArrangement = Arrangement.spacedBy(4.dp),
+                        ) {
+                            Text(
+                                text = "Enable skills catalog",
+                                style = MaterialTheme.typography.titleMedium,
+                            )
+                            Text(
+                                text = "Expose selected skills from ${skillsState.rootPath.ifBlank { "(not resolved)" }} to the model as a lightweight catalog.",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        }
+                        Switch(
+                            checked = assistant.skillsEnabled,
+                            onCheckedChange = {
+                                onUpdateAssistant(assistant.copy(skillsEnabled = it))
+                            },
+                        )
+                    }
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Text(
+                            text = "Selected: ${assistant.selectedSkills.size}",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                        Box(modifier = Modifier.weight(1f))
+                        TextButton(onClick = onRefresh) {
+                            Text("Refresh")
+                        }
+                    }
+                }
+            }
+        }
+
+        if (!termuxToolEnabled) {
+            item("termux-warning") {
+                SkillsInfoCard(
+                    title = "Termux tool required",
+                    text = "Enable Local Tools > Termux Command before using skills in chat.",
+                    isError = true,
+                )
+            }
+        }
+
+        if (!modelSupportsTools) {
+            item("model-warning") {
+                SkillsInfoCard(
+                    title = "Current model cannot use tools",
+                    text = "Selections are saved, but the skills catalog will not be injected until the active model supports tool calls.",
+                    isError = false,
+                )
+            }
+        }
+
+        if (skillsState.error != null) {
+            item("error") {
+                SkillsInfoCard(
+                    title = "Failed to refresh skills",
+                    text = skillsState.error.orEmpty(),
+                    isError = true,
+                )
+            }
+        }
+
+        if (skillsState.isLoading) {
+            item("loading") {
+                Card {
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 16.dp, vertical = 12.dp),
+                        horizontalArrangement = Arrangement.spacedBy(12.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        CircularProgressIndicator(modifier = Modifier.size(20.dp))
+                        Text("Refreshing skills from ${skillsState.rootPath.ifBlank { "workdir/skills" }}")
+                    }
+                }
+            }
+        }
+
+        if (!skillsState.isLoading && skillsState.entries.isEmpty() && skillsState.invalidEntries.isEmpty()) {
+            item("empty") {
+                SkillsInfoCard(
+                    title = "No skills found",
+                    text = "Create subdirectories under ${skillsState.rootPath.ifBlank { "workdir/skills" }} and add a SKILL.md with name and description frontmatter.",
+                    isError = false,
+                )
+            }
+        }
+
+        if (skillsState.entries.isNotEmpty()) {
+            item("available-header") {
+                Text(
+                    text = "Available skills",
+                    style = MaterialTheme.typography.titleMedium,
+                    modifier = Modifier.padding(horizontal = 4.dp),
+                )
+            }
+            items(
+                items = skillsState.entries,
+                key = { it.directoryName },
+            ) { entry ->
+                SkillEntryCard(
+                    entry = entry,
+                    checked = entry.directoryName in assistant.selectedSkills,
+                    onCheckedChange = { checked ->
+                        val nextSelection = assistant.selectedSkills.toMutableSet().apply {
+                            if (checked) add(entry.directoryName) else remove(entry.directoryName)
+                        }
+                        onUpdateAssistant(assistant.copy(selectedSkills = nextSelection))
+                    },
+                )
+            }
+        }
+
+        if (missingSelections.isNotEmpty()) {
+            item("missing-header") {
+                Text(
+                    text = "Missing selections",
+                    style = MaterialTheme.typography.titleMedium,
+                    modifier = Modifier.padding(horizontal = 4.dp),
+                )
+            }
+            items(
+                items = missingSelections,
+                key = { it },
+            ) { directoryName ->
+                Card {
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 16.dp, vertical = 12.dp),
+                        horizontalArrangement = Arrangement.spacedBy(16.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Icon(HugeIcons.Alert01, contentDescription = null)
+                        Column(
+                            modifier = Modifier.weight(1f),
+                            verticalArrangement = Arrangement.spacedBy(4.dp),
+                        ) {
+                            Text(text = directoryName, style = MaterialTheme.typography.titleMedium)
+                            Text(
+                                text = "This skill is still selected on the assistant, but it no longer exists in ${skillsState.rootPath.ifBlank { "workdir/skills" }}.",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        }
+                        Switch(
+                            checked = true,
+                            onCheckedChange = { checked ->
+                                if (!checked) {
+                                    onUpdateAssistant(
+                                        assistant.copy(
+                                            selectedSkills = assistant.selectedSkills - directoryName
+                                        )
+                                    )
+                                }
+                            },
+                        )
+                    }
+                }
+            }
+        }
+
+        if (skillsState.invalidEntries.isNotEmpty()) {
+            item("invalid-header") {
+                Text(
+                    text = "Ignored directories",
+                    style = MaterialTheme.typography.titleMedium,
+                    modifier = Modifier.padding(horizontal = 4.dp),
+                )
+            }
+            items(
+                items = skillsState.invalidEntries,
+                key = { "${it.directoryName}:${it.reason}" },
+            ) { entry ->
+                InvalidSkillEntryCard(entry = entry)
+            }
+        }
+    }
+}
+
+@Composable
+private fun SkillEntryCard(
+    entry: SkillCatalogEntry,
+    checked: Boolean,
+    onCheckedChange: (Boolean) -> Unit,
+) {
+    Card {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 12.dp),
+            horizontalArrangement = Arrangement.spacedBy(16.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Icon(HugeIcons.Package01, contentDescription = null)
+            Column(
+                modifier = Modifier.weight(1f),
+                verticalArrangement = Arrangement.spacedBy(4.dp),
+            ) {
+                Text(
+                    text = entry.name,
+                    style = MaterialTheme.typography.titleMedium,
+                )
+                if (entry.name != entry.directoryName) {
+                    Text(
+                        text = entry.directoryName,
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+                Text(
+                    text = entry.description,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                HorizontalDivider(modifier = Modifier.padding(vertical = 4.dp))
+                Text(
+                    text = entry.path,
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            Switch(
+                checked = checked,
+                onCheckedChange = onCheckedChange,
+            )
+        }
+    }
+}
+
+@Composable
+private fun InvalidSkillEntryCard(entry: SkillInvalidEntry) {
+    Card {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 12.dp),
+            horizontalArrangement = Arrangement.spacedBy(16.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Icon(HugeIcons.Alert01, contentDescription = null)
+            Column(
+                modifier = Modifier.weight(1f),
+                verticalArrangement = Arrangement.spacedBy(4.dp),
+            ) {
+                Text(
+                    text = entry.directoryName,
+                    style = MaterialTheme.typography.titleMedium,
+                )
+                Text(
+                    text = entry.reason,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Text(
+                    text = entry.path,
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun SkillsInfoCard(
+    title: String,
+    text: String,
+    isError: Boolean,
+) {
+    Card {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 12.dp),
+            horizontalArrangement = Arrangement.spacedBy(16.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Icon(
+                imageVector = HugeIcons.Alert01,
+                contentDescription = null,
+                tint = if (isError) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.primary,
+            )
+            Column(
+                modifier = Modifier.weight(1f),
+                verticalArrangement = Arrangement.spacedBy(4.dp),
+            ) {
+                Text(
+                    text = title,
+                    style = MaterialTheme.typography.titleMedium,
+                    color = if (isError) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.onSurface,
+                )
+                Text(
+                    text = text,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/assistant/detail/AssistantDetailPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/assistant/detail/AssistantDetailPage.kt
@@ -6,6 +6,7 @@ import me.rerere.hugeicons.stroke.Brain02
 import me.rerere.hugeicons.stroke.ArrowRight01
 import me.rerere.hugeicons.stroke.Code
 import me.rerere.hugeicons.stroke.Message02
+import me.rerere.hugeicons.stroke.Package01
 import me.rerere.hugeicons.stroke.Settings03
 import me.rerere.hugeicons.stroke.Injection
 import me.rerere.hugeicons.stroke.Wrench01
@@ -140,6 +141,13 @@ fun AssistantDetailPage(id: String) {
                         leadingContent = { Icon(HugeIcons.BookOpen01, null) },
                         supportingContent = { Text(stringResource(R.string.assistant_detail_local_tools_desc)) },
                         headlineContent = { Text(stringResource(R.string.assistant_page_tab_local_tools)) },
+                        trailingContent = { Icon(HugeIcons.ArrowRight01, null) },
+                    )
+                    item(
+                        onClick = { navController.navigate(Screen.AssistantSkills(id)) },
+                        leadingContent = { Icon(HugeIcons.Package01, null) },
+                        supportingContent = { Text(stringResource(R.string.assistant_detail_skills_desc)) },
+                        headlineContent = { Text(stringResource(R.string.assistant_page_tab_skills)) },
                         trailingContent = { Icon(HugeIcons.ArrowRight01, null) },
                     )
                 }

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/assistant/detail/AssistantDetailVM.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/assistant/detail/AssistantDetailVM.kt
@@ -18,6 +18,7 @@ import me.rerere.rikkahub.data.model.AssistantMemory
 import me.rerere.rikkahub.data.model.Avatar
 import me.rerere.rikkahub.data.model.Tag
 import me.rerere.rikkahub.data.repository.MemoryRepository
+import me.rerere.rikkahub.data.skills.SkillsRepository
 import kotlin.uuid.Uuid
 
 private const val TAG = "AssistantDetailVM"
@@ -27,6 +28,7 @@ class AssistantDetailVM(
     private val settingsStore: SettingsStore,
     private val memoryRepository: MemoryRepository,
     private val filesManager: FilesManager,
+    private val skillsRepository: SkillsRepository,
 ) : ViewModel() {
     private val assistantId = Uuid.parse(id)
 
@@ -67,6 +69,8 @@ class AssistantDetailVM(
         }.stateIn(
             scope = viewModelScope, started = SharingStarted.Eagerly, initialValue = emptyList()
         )
+
+    val skillsState = skillsRepository.state
 
     val tags = settingsStore
         .settingsFlow
@@ -198,5 +202,9 @@ class AssistantDetailVM(
                 Log.w(TAG, "Failed to delete background file: $oldBackground", e)
             }
         }
+    }
+
+    fun refreshSkills() {
+        skillsRepository.requestRefresh()
     }
 }

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/assistant/detail/AssistantSkillsPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/assistant/detail/AssistantSkillsPage.kt
@@ -1,0 +1,75 @@
+package me.rerere.rikkahub.ui.pages.assistant.detail
+
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.LargeFlexibleTopAppBar
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import me.rerere.ai.provider.ModelAbility
+import me.rerere.rikkahub.R
+import me.rerere.rikkahub.data.datastore.findModelById
+import me.rerere.rikkahub.data.datastore.getCurrentChatModel
+import me.rerere.rikkahub.ui.components.ai.SkillsPicker
+import me.rerere.rikkahub.ui.components.nav.BackButton
+import me.rerere.rikkahub.ui.theme.CustomColors
+import org.koin.androidx.compose.koinViewModel
+import org.koin.core.parameter.parametersOf
+
+@Composable
+fun AssistantSkillsPage(id: String) {
+    val vm: AssistantDetailVM = koinViewModel(
+        parameters = {
+            parametersOf(id)
+        }
+    )
+    val assistant by vm.assistant.collectAsStateWithLifecycle()
+    val skillsState by vm.skillsState.collectAsStateWithLifecycle()
+    val settings by vm.settings.collectAsStateWithLifecycle()
+    val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior()
+    val model = assistant.chatModelId?.let { settings.findModelById(it) } ?: settings.getCurrentChatModel()
+    val modelSupportsTools = model?.abilities?.contains(ModelAbility.TOOL) == true
+
+    LaunchedEffect(Unit) {
+        vm.refreshSkills()
+    }
+
+    Scaffold(
+        topBar = {
+            LargeFlexibleTopAppBar(
+                title = {
+                    Text(text = stringResource(R.string.assistant_page_tab_skills))
+                },
+                navigationIcon = {
+                    BackButton()
+                },
+                scrollBehavior = scrollBehavior,
+                colors = CustomColors.topBarColors,
+            )
+        },
+        modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
+        containerColor = CustomColors.topBarColors.containerColor,
+    ) { innerPadding ->
+        SkillsPicker(
+            assistant = assistant,
+            skillsState = skillsState,
+            modelSupportsTools = modelSupportsTools,
+            onRefresh = vm::refreshSkills,
+            onUpdateAssistant = vm::update,
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding)
+                .padding(horizontal = 16.dp)
+                .imePadding(),
+        )
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -11,6 +11,7 @@
   <string name="assistant_detail_basic_desc">Configure name, avatar, model, and parameters</string>
   <string name="assistant_detail_injections_desc">Configure message templates and lorebooks</string>
   <string name="assistant_detail_local_tools_desc">Enable local tools like JavaScript engine</string>
+  <string name="assistant_detail_skills_desc">Choose local skills from the Termux workdir</string>
   <string name="assistant_detail_mcp_desc">Configure MCP server tools for the assistant</string>
   <string name="assistant_detail_memory_desc">Manage assistant memory and recent chat references</string>
   <string name="assistant_detail_prompt_desc">Set system prompts, message templates, and regex rules</string>
@@ -124,6 +125,7 @@
   <string name="assistant_page_tab_basic">Basic Settings</string>
   <string name="assistant_page_tab_injections">Prompt Injections</string>
   <string name="assistant_page_tab_local_tools">Local Tools</string>
+  <string name="assistant_page_tab_skills">Skills</string>
   <string name="assistant_page_tab_mcp">MCP</string>
   <string name="assistant_page_tab_memory">Memory</string>
   <string name="assistant_page_tab_prompt">Prompts</string>

--- a/app/src/test/java/me/rerere/rikkahub/data/model/AssistantSkillsSerializationTest.kt
+++ b/app/src/test/java/me/rerere/rikkahub/data/model/AssistantSkillsSerializationTest.kt
@@ -1,0 +1,26 @@
+package me.rerere.rikkahub.data.model
+
+import me.rerere.rikkahub.utils.JsonInstant
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AssistantSkillsSerializationTest {
+    @Test
+    fun `decode old assistant json should keep skills defaults`() {
+        val assistant = JsonInstant.decodeFromString<Assistant>(
+            """
+                {
+                  "name": "Legacy Assistant",
+                  "termuxNeedsApproval": false
+                }
+            """.trimIndent()
+        )
+
+        assertEquals("Legacy Assistant", assistant.name)
+        assertFalse(assistant.termuxNeedsApproval)
+        assertFalse(assistant.skillsEnabled)
+        assertTrue(assistant.selectedSkills.isEmpty())
+    }
+}

--- a/app/src/test/java/me/rerere/rikkahub/data/skills/SkillsPromptTest.kt
+++ b/app/src/test/java/me/rerere/rikkahub/data/skills/SkillsPromptTest.kt
@@ -1,0 +1,115 @@
+package me.rerere.rikkahub.data.skills
+
+import me.rerere.ai.provider.Model
+import me.rerere.ai.provider.ModelAbility
+import me.rerere.rikkahub.data.ai.tools.LocalToolOption
+import me.rerere.rikkahub.data.model.Assistant
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SkillsPromptTest {
+    @Test
+    fun `parseSkillFrontmatter should extract name and description`() {
+        val markdown = """
+            ---
+            name: find-hugeicons
+            description: "Use this skill when the user asks for icons: search before coding"
+            ---
+            
+            # Find HugeIcons
+        """.trimIndent()
+
+        val result = parseSkillFrontmatter(markdown)
+
+        assertTrue(result is SkillFrontmatterParseResult.Success)
+        val frontmatter = (result as SkillFrontmatterParseResult.Success).frontmatter
+        assertEquals("find-hugeicons", frontmatter.name)
+        assertEquals("Use this skill when the user asks for icons: search before coding", frontmatter.description)
+    }
+
+    @Test
+    fun `parseSkillFrontmatter should reject missing description`() {
+        val markdown = """
+            ---
+            name: find-hugeicons
+            ---
+        """.trimIndent()
+
+        val result = parseSkillFrontmatter(markdown)
+
+        assertTrue(result is SkillFrontmatterParseResult.Error)
+        assertEquals(
+            "SKILL.md frontmatter is missing description",
+            (result as SkillFrontmatterParseResult.Error).reason,
+        )
+    }
+
+    @Test
+    fun `buildSkillsCatalogPrompt should include selected valid skills only`() {
+        val assistant = Assistant(
+            skillsEnabled = true,
+            selectedSkills = setOf("find-hugeicons", "missing-skill"),
+            localTools = listOf(LocalToolOption.TimeInfo, LocalToolOption.TermuxExec),
+        )
+        val model = Model(abilities = listOf(ModelAbility.TOOL))
+        val catalog = SkillsCatalogState(
+            workdir = "/data/data/com.termux/files/home",
+            rootPath = "/data/data/com.termux/files/home/skills",
+            entries = listOf(
+                SkillCatalogEntry(
+                    directoryName = "find-hugeicons",
+                    path = "/data/data/com.termux/files/home/skills/find-hugeicons",
+                    name = "find-hugeicons",
+                    description = "Search the HugeIcons library before using an icon.",
+                ),
+                SkillCatalogEntry(
+                    directoryName = "locale-tui-localization",
+                    path = "/data/data/com.termux/files/home/skills/locale-tui-localization",
+                    name = "locale-tui-localization",
+                    description = "Use locale-tui for Android localization tasks.",
+                ),
+            ),
+        )
+
+        val prompt = buildSkillsCatalogPrompt(
+            assistant = assistant,
+            model = model,
+            catalog = catalog,
+        )
+
+        assertNotNull(prompt)
+        assertTrue(prompt!!.contains("Skills root: /data/data/com.termux/files/home/skills"))
+        assertTrue(prompt.contains("find-hugeicons"))
+        assertTrue(prompt.contains("Search the HugeIcons library before using an icon."))
+        assertFalse(prompt.contains("locale-tui-localization"))
+        assertFalse(prompt.contains("missing-skill"))
+    }
+
+    @Test
+    fun `buildSkillsCatalogPrompt should be disabled when model cannot use tools`() {
+        val assistant = Assistant(
+            skillsEnabled = true,
+            selectedSkills = setOf("find-hugeicons"),
+            localTools = listOf(LocalToolOption.TermuxExec),
+        )
+        val model = Model(abilities = emptyList())
+        val catalog = SkillsCatalogState(
+            rootPath = "/data/data/com.termux/files/home/skills",
+            entries = listOf(
+                SkillCatalogEntry(
+                    directoryName = "find-hugeicons",
+                    path = "/data/data/com.termux/files/home/skills/find-hugeicons",
+                    name = "find-hugeicons",
+                    description = "Search the HugeIcons library before using an icon.",
+                )
+            ),
+        )
+
+        assertNull(buildSkillsCatalogPrompt(assistant = assistant, model = model, catalog = catalog))
+        assertFalse(shouldInjectSkillsCatalog(assistant = assistant, model = model))
+    }
+}


### PR DESCRIPTION
## Summary
- add local skills discovery under `${termuxWorkdir}/skills` using existing Termux execution
- inject selected skills as a lightweight catalog into generation and persist assistant-level skill selection
- add assistant settings and chat input pickers for enabling and selecting local skills
- add unit coverage for frontmatter parsing and assistant serialization defaults

## Testing
- ./gradlew :app:testDebugUnitTest